### PR TITLE
fix: get TXT records explicitly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 const Cloudflare = require('cloudflare')
+const axios = require('axios')
 
 async function getZoneId (api, name) {
   const zones = await api.zones.browse()
@@ -13,7 +14,20 @@ async function getZoneId (api, name) {
 }
 
 async function getRecord (api, id, name) {
-  const records = await api.dnsRecords.browse(id)
+  const authHeader = api._client.token ? {
+    Authorization: `Bearer ${api._client.token}`
+  } : {
+    'X-Auth-Email': api._client.email,
+    'X-Auth-Key': api._client.key
+  }
+
+  const records = await axios({
+    url: `https://api.cloudflare.com/client/v4/zones/${id}/dns_records`,
+    headers: authHeader,
+    params: {
+      type: 'TXT'
+    }
+  }).then(resp => resp.data)
 
   for (const record of records.result) {
     if (record.type === 'TXT' && record.name === name && record.content.startsWith('dnslink=')) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,6 +112,14 @@
       "resolved": "https://registry.npmjs.org/autocreate/-/autocreate-1.2.0.tgz",
       "integrity": "sha1-UiFnmSxBcsFUeeX4jzSGpFKkDLo="
     },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -827,6 +835,29 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
       "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "url": "https://github.com/ipfs-shipyard/dnslink-cloudflare"
   },
   "dependencies": {
+    "axios": "^0.19.2",
     "cloudflare": "^2.7.0",
     "yargs": "^15.0.1"
   },


### PR DESCRIPTION
When I was using ipfs-deploy, it **never** detects my existing TXT record and always adds one record over a different TXT record without deleting it. After testing with Cloudflare API, it seems that I can only get A/CAA/CNAME records without explicitly defining the type. TXT records can be obtained only if I explicitly tell the API.
Here I used axios (which is a dep of ipfs-deploy, and thus is unlikely to add extra dependencies for end users) to add the header manually, since node-cloudflare doesn't seem to provide a way.