### PR TITLE
docs: add CLI environment variables to usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,16 @@
 npx dnslink-cloudflare -d <domain> -l <link> [-r record]
 ```
 
-Required environment variables
+### Environment variables
+
+It can be done two ways. The first is with email and API key.
 
 - `CF_API_KEY` CloudFlare API key
 - `CF_API_EMAIL` CloudFlare API email
-- `CF_API_TOKEN` CloudFlare API token
+
+The second is with just the API token.
+
+`CF_API_TOKEN` CloudFlare API token
 
 These values are obtained from in the CloudFlare account. https://dash.cloudflare.com/profile/api-tokens
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,17 @@
 
 ## Usage
 
-```
+```sh
 npx dnslink-cloudflare -d <domain> -l <link> [-r record]
 ```
+
+Required environment variables
+
+- `CF_API_KEY` CloudFlare API key
+- `CF_API_EMAIL` CloudFlare API email
+- `CF_API_TOKEN` CloudFlare API token
+
+These values are obtained from in the CloudFlare account. https://dash.cloudflare.com/profile/api-tokens
 
 ## Contributing
 


### PR DESCRIPTION
## What does it do?

It adds environment variables list to markdown usage docs.

## How to test?

I don't know but I didn't test it. I just looked in the CLI, node bin, file. https://github.com/ipfs-shipyard/dnslink-cloudflare/blob/master/bin/index.js#L29